### PR TITLE
Avoid php warning

### DIFF
--- a/tests/ReadabilityTest.php
+++ b/tests/ReadabilityTest.php
@@ -443,7 +443,7 @@ class ReadabilityTest extends \PHPUnit_Framework_TestCase
 
     public function testPostFilters()
     {
-        $readability = $this->getReadability('<div>' . str_repeat('<p>This <b>is</b> the awesome content :)</p>', 7) . '</div>', 'http://0.0.0.0');
+        $readability = $this->getReadability('<div>' . str_repeat('<p>This <b>is</b> the awesome content :)</p>', 10) . '</div>', 'http://0.0.0.0');
         $readability->addPostFilter('!<strong[^>]*>(.*?)</strong>!is', '');
 
         $res = $readability->init();


### PR DESCRIPTION
This isn't the best solution but the previous one using `@` wasn't really better.
Appending a string into a fragment might generate some warning if the string contains bad entity.
For example `&plus;`.

Fix https://github.com/j0k3r/php-readability/issues/29