### PR TITLE
Updating to 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
     - hhvm
 
@@ -24,12 +25,9 @@ matrix:
           env: CS_FIXER=run
     fast_finish: true
     allow_failures:
-        - php: 7.2
+        - php: 7.3
         - php: nightly
         - php: hhvm
-
-# faster builds on new travis setup not using sudo
-sudo: false
 
 # cache vendor dirs
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
     - 7.2
     - 7.3
     - nightly
-    - hhvm
 
 matrix:
     include:
@@ -27,7 +26,6 @@ matrix:
     allow_failures:
         - php: 7.3
         - php: nightly
-        - php: hhvm
 
 # cache vendor dirs
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,12 @@ before_install:
     # see: https://blog.travis-ci.com/upcoming_ubuntu_11_10_migration/
     - if [[ $TRAVIS_PHP_VERSION = 5.3.3 ]]; then composer config -g -- disable-tls true; fi;
     - if [[ $TRAVIS_PHP_VERSION = 5.3.3 ]]; then composer config -g -- secure-http false; fi;
-    # no version compatible with PHP > 7.1
-    - if [[ $TRAVIS_PHP_VERSION = 7.2.* ]]; then composer remove friendsofphp/php-cs-fixer; fi;
 
 install:
     - composer self-update
 
 before_script:
-    - composer install --prefer-dist --no-interaction
+    - composer install -o --prefer-dist --no-interaction
 
 script:
     - mkdir -p build/logs

--- a/tests/ReadabilityTest.php
+++ b/tests/ReadabilityTest.php
@@ -6,7 +6,7 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Readability\Readability;
 
-class ReadabilityTest extends \PHPUnit_Framework_TestCase
+class ReadabilityTest extends \PHPUnit\Framework\TestCase
 {
     public $logHandler;
     public $logger;


### PR DESCRIPTION
- Add a build for 7.3, just in case.
- Update PHPUnit to work on PHP 7.2.
- Remove `sudo: false` to use the new Travis infra.