### PR TITLE
Composer bump, php-cs bump to v2, travis update

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,20 +1,25 @@
 <?php
 
-return Symfony\CS\Config\Config::create()
+return PhpCsFixer\Config::create()
     ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    // use default SYMFONY_LEVEL and extra fixers:
-    ->fixers(array(
-        'concat_with_spaces',
-        'ordered_use',
-        'phpdoc_order',
-        'strict',
-        'strict_param',
-        'long_array_syntax',
-    ))
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        'concat_space' => [
+            'spacing' => 'one',
+        ],
+        'ordered_imports' => true,
+        'phpdoc_order' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'array_syntax' => [
+            'syntax' => 'long',
+        ],
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude([
+                'vendor',
+            ])
             ->in(__DIR__)
-            ->exclude(array('vendor'))
     )
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
@@ -11,20 +10,10 @@ php:
 
 matrix:
     include:
-        - php: 5.3.3
-          dist: precise
-          sudo: required
-        - php: 5.3
-          dist: precise
-          sudo: required
-        - php: 5.4
-          dist: precise
-          sudo: required
-        - php: 7.0
+        - php: 7.2
           env: CS_FIXER=run
     fast_finish: true
     allow_failures:
-        - php: 7.3
         - php: nightly
 
 # cache vendor dirs
@@ -35,10 +24,6 @@ cache:
 
 before_install:
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
-    # disable TLS for composer because openssl is disabled for PHP 5.3.3 on travis
-    # see: https://blog.travis-ci.com/upcoming_ubuntu_11_10_migration/
-    - if [[ $TRAVIS_PHP_VERSION = 5.3.3 ]]; then composer config -g -- disable-tls true; fi;
-    - if [[ $TRAVIS_PHP_VERSION = 5.3.3 ]]; then composer config -g -- secure-http false; fi;
 
 install:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -24,16 +24,16 @@
         "role": "Developer (original JS version)"
     }],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.6.0",
         "ext-mbstring": "*",
         "psr/log": "^1.0",
         "electrolinux/php-html5lib": "^0.1.0"
     },
     "require-dev": {
-        "satooshi/php-coveralls": "~0.6",
-        "friendsofphp/php-cs-fixer": "<2",
-        "monolog/monolog": "^1.13",
-        "symfony/phpunit-bridge": "^3.2"
+        "php-coveralls/php-coveralls": "^2.1",
+        "friendsofphp/php-cs-fixer": "^2.14",
+        "monolog/monolog": "^1.24",
+        "symfony/phpunit-bridge": "^4.2.3"
     },
     "suggest": {
         "ext-tidy": "Used to clean up given HTML and to avoid problems with bad HTML structure."


### PR DESCRIPTION
Bump composer dependencies and move php-cs to v2.

Also remove Travis tests and stuff related to php < 5.6. Move php-cs to php 7.2 and don't allow failures on 7.3 anymore.

Tests will fail, because #42 is not merged yet.