### PR TITLE
Skip empty (empty innerHTML) nodes when grabbing article

### DIFF
--- a/src/Readability.php
+++ b/src/Readability.php
@@ -1008,6 +1008,12 @@ class Readability implements LoggerAwareInterface
         for ($nodeIndex = 0; ($node = $allElements->item($nodeIndex)); ++$nodeIndex) {
             $tagName = $node->tagName;
 
+            $nodeContent = $node->getInnerHTML();
+            if (empty($nodeContent)) {
+                $this->logger->debug('Skipping empty node');
+                continue;
+            }
+
             // Some well known site uses sections as paragraphs.
             if (0 === strcasecmp($tagName, 'p') || 0 === strcasecmp($tagName, 'td') || 0 === strcasecmp($tagName, 'pre') || 0 === strcasecmp($tagName, 'section')) {
                 $nodesToScore[] = $node;
@@ -1016,11 +1022,11 @@ class Readability implements LoggerAwareInterface
             // Turn divs into P tags where they have been used inappropriately
             //  (as in, where they contain no other block level elements).
             if (0 === strcasecmp($tagName, 'div') || 0 === strcasecmp($tagName, 'article') || 0 === strcasecmp($tagName, 'section')) {
-                if (!preg_match($this->regexps['divToPElements'], $node->getInnerHTML())) {
+                if (!preg_match($this->regexps['divToPElements'], $nodeContent)) {
                     $newNode = $this->dom->createElement('p');
 
                     try {
-                        $newNode->setInnerHtml($node->getInnerHTML());
+                        $newNode->setInnerHtml($nodeContent);
 
                         $node->parentNode->replaceChild($newNode, $node);
                         --$nodeIndex;


### PR DESCRIPTION
Fix #51.

Hi!

This skips nodes for which there is no content (innerHTML is empty) to make it a bit quicker to grab an article and also to make the debug easier.

I don't expect any change on the content returned but I don't know how to test it other than manually. I'm all ears if you have requests/suggestions.