### PR TITLE
Strip script and style tags through `::clean()` method instead of `preg_replace`

### DIFF
--- a/src/Readability.php
+++ b/src/Readability.php
@@ -137,10 +137,6 @@ class Readability implements LoggerAwareInterface
     protected $useTidy;
     // raw HTML filters
     protected $pre_filters = [
-        // remove obvious scripts
-        '!<script[^>]*>(.*?)</script>!is' => '',
-        // remove obvious styles
-        '!<style[^>]*>(.*?)</style>!is' => '',
         // remove spans as we redefine styles and they're probably special-styled
         '!</?span[^>]*>!is' => '',
         // HACK: firewall-filtered content
@@ -396,6 +392,9 @@ class Readability implements LoggerAwareInterface
         }
 
         $this->logger->debug($this->lightClean ? 'Light clean enabled.' : 'Standard clean enabled.');
+
+        $this->clean($articleContent, 'style');
+        $this->clean($articleContent, 'script');
 
         $this->cleanStyles($articleContent);
         $this->killBreaks($articleContent);


### PR DESCRIPTION
Huge tags can lead to a failure of preg_replace, thus erasing the whole
fetched content.

E.g.: https://slate.com/news-and-politics/2020/08/joe-biden-empathy-candidate.html

Fixes https://github.com/wallabag/wallabag/issues/5847