### PR TITLE
[1.x] php-cs-fixer: Disable incompatible rules

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -30,6 +30,10 @@ return (new PhpCsFixer\Config())
         'no_null_property_initialization' => false,
         // Pulled in by @Symfony with `const` but const visibility requires PHP ≥ 7.1
         'visibility_required' => ['elements' => ['method', 'property']],
+        // Pulled in by @Symfony:risky but we still support PHP ≤ 7.4
+        'modernize_strpos' => false,
+        // Enabled by @Symfony:risky but requires PHP 8.
+        'get_class_to_class_keyword' => false,
     ])
     ->setFinder($finder)
 ;


### PR DESCRIPTION
The `modernize_strpos` rule was disabled in 648d8c605b21c54fbcd395354181ed1b044cc664 on master.
We do not need to care about `no_null_property_initialization` since we are stuck on PHP-CS-Fixer 2.

Also disable `get_class_to_class_keyword`, which is not an issue on master since the `get_class` was removed in b580cf216d9001f82c866bb9a6c8bcad1cc862d8.
