### PR TITLE
Fix character decoding regression when `title` precedes `meta[charset]`

### DIFF
--- a/src/Readability.php
+++ b/src/Readability.php
@@ -1422,7 +1422,7 @@ class Readability implements LoggerAwareInterface
             unset($tidy);
         }
 
-        $this->html = self::ensureMetaCharset((string) $this->html);
+        $this->html = self::entitizeNonAscii((string) $this->html);
 
         if ('html5lib' === $this->parser || 'html5' === $this->parser) {
             $this->dom = (new HTML5())->loadHTML($this->html);
@@ -1512,43 +1512,19 @@ class Readability implements LoggerAwareInterface
     }
 
     /**
-     * Tries to insert `meta[charset]` tag into the proper place in the passed HTML document.
+     * Converts non-ASCII UTF-8 characters to numeric HTML entities.
      *
      * `DOMDocument::loadHTML` will parse HTML documents as ISO-8859-1 if there is no `meta[charset]` tag.
      * This means that UTF-8-encoded HTML fragments such as those coming from JSON-LD `articleBody` field would be parsed with incorrect encoding.
-     * Unfortunately, we cannot just put the tag at the start of the HTML fragment, since that would cause parser to auto-insert a `html` element, losing the attributes of the original `html` tag.
      *
      * @param string $html UTF-8 encoded document
      */
-    private static function ensureMetaCharset(string $html): string
+    private static function entitizeNonAscii(string $html): string
     {
-        $charsetTag = '<meta charset="utf-8">';
+        $convmap = [
+            0x80, 0x1FFFFF, 0, 0x10FFFF,
+        ];
 
-        // Only look at first 1024 bytes since, according to HTML5 specification,
-        // that’s where <meta> elements declaring a character encoding must be located.
-        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#charset
-        $start = substr($html, 0, 1000);
-
-        if (1 === preg_match('/<meta[^>]+charset/i', $start)) {
-            // <meta> tag is already present, no need for modification.
-            return $html;
-        }
-
-        if (1 === preg_match('/<head[^>]*>/i', $start)) {
-            // <head> tag was located, <meta> tags go there.
-            $html = preg_replace('/<head[^>]*>/i', '$0' . $charsetTag, $html, 1);
-
-            return $html;
-        }
-
-        if (1 === preg_match('/<html[^>]*>/i', $start)) {
-            // <html> tag was located, let’s put it inside and have parser create <head>.
-            $html = preg_replace('/<html[^>]*>/i', '$0' . $charsetTag, $html, 1);
-
-            return $html;
-        }
-
-        // Fallback – just plop the <meta> at the start of the fragment.
-        return $charsetTag . $html;
+        return mb_encode_numericentity($html, $convmap, 'utf8', true);
     }
 }

--- a/tests/ReadabilityTest.php
+++ b/tests/ReadabilityTest.php
@@ -536,21 +536,21 @@ class ReadabilityTest extends \PHPUnit\Framework\TestCase
     {
         return [
             'meta' => [
-                '<html lang="fr"><head><meta charset="utf-8"></head><body><article>' . str_repeat('<p>This is the awesome content :)</p>', 7) . '</article></body></html>',
+                '<html lang="fr"><head><meta charset="utf-8"></head><body><article>' . str_repeat('<p>Tous les êtres humains naissent libres et égaux en dignité et en droits. Ils sont doués de raison et de conscience et doivent agir les uns envers les autres dans un esprit de fraternité.</p>', 7) . '</article></body></html>',
                 'fr',
             ],
             'head' => [
-                '<html lang="fr"><head><title>Foo</title></head><body><article>' . str_repeat('<p>This is the awesome content :)</p>', 7) . '</article></body></html>',
+                '<html lang="fr"><head><title>Foo</title></head><body><article>' . str_repeat('<p>Tous les êtres humains naissent libres et égaux en dignité et en droits. Ils sont doués de raison et de conscience et doivent agir les uns envers les autres dans un esprit de fraternité.</p>', 7) . '</article></body></html>',
                 'fr',
             ],
             'headless' => [
-                '<html lang="fr"><body><article>' . str_repeat('<p>This is the awesome content :)</p>', 7) . '</article></body></html>',
+                '<html lang="fr"><body><article>' . str_repeat('<p>Tous les êtres humains naissent libres et égaux en dignité et en droits. Ils sont doués de raison et de conscience et doivent agir les uns envers les autres dans un esprit de fraternité.</p>', 7) . '</article></body></html>',
                 'fr',
                 // tidy would add <head> tag.
                 false,
             ],
             'fragment' => [
-                '<article>' . str_repeat('<p>This is the awesome content :)</p>', 7) . '</article>',
+                '<article>' . str_repeat('<p>Tous les êtres humains naissent libres et égaux en dignité et en droits. Ils sont doués de raison et de conscience et doivent agir les uns envers les autres dans un esprit de fraternité.</p>', 7) . '</article>',
                 '',
                 // tidy would add <html>.
                 false,
@@ -569,6 +569,8 @@ class ReadabilityTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($res);
         $this->assertInstanceOf(\DOMDocument::class, $readability->dom);
         $this->assertSame($lang, $readability->dom->documentElement->getAttribute('lang'));
+        $this->assertInstanceOf('Readability\JSLikeHTMLElement', $readability->getContent());
+        $this->assertStringContainsString('êtres', $readability->getContent()->getInnerHtml());
     }
 
     private function getReadability(string $html, ?string $url = null, string $parser = 'libxml', bool $useTidy = true): Readability

--- a/tests/ReadabilityTest.php
+++ b/tests/ReadabilityTest.php
@@ -529,6 +529,20 @@ class ReadabilityTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    // https://github.com/wallabag/wallabag/issues/8158
+    public function testCharsetAfterTitle(): void
+    {
+        $readability = $this->getReadability('<!DOCTYPE html><html lang="et"><head><title>Tõde ja õigus I</title> <meta charset="utf-8"></head><body><p>See oli läinud aastasaja kolmanda veerandi lõpul. Päike lähenes silmapiirile, seistes sedavõrd madalas, et enam ei ulatunud valgustama ei mäkke ronivat hobust, kes puutelgedega vankrit vedas, ei vankril istuvat noort naist ega ka ligi kolmekümnelist meest, kes kõndis vankri kõrval.</p></body></html>', 'https://et.wikisource.org/wiki/T%C3%B5de_ja_%C3%B5igus_I/I');
+        $readability->convertLinksToFootnotes = true;
+        $res = $readability->init();
+
+        $this->assertTrue($res);
+        $this->assertInstanceOf('Readability\JSLikeHTMLElement', $readability->getContent());
+        $this->assertInstanceOf('Readability\JSLikeHTMLElement', $readability->getTitle());
+        $this->assertSame('Tõde ja õigus I', $readability->getTitle()->getInnerHtml());
+        $this->assertStringContainsString('Päike lähenes', $readability->getContent()->getInnerHtml());
+    }
+
     /**
      * @return array<string, array{0: string, 1: string, 2?: bool}>
      */


### PR DESCRIPTION
Fix character decoding regression when `title` precedes `meta[charset]`

Because of PHP 8.2 deprecation, in f14428e4c0fa34b28f6b8a7696e62790bcde363e, we stopped converting non-ASCII characters to HTML entities. Instead, we started to explicitly insert `meta[charset]` tag at the start of the document.

Later, we discovered that was breaking `html[lang]` so, in efbbc86df9716a3ab1ed8a351d9e8316f3a2aab0, we made the insertion smarter. One of the improvements was that it would not insert the `meta[charset]` tag when it was already present.

That, however, broke websites that had `title` tag before `meta[charset]`. On those, libxml2 would decode the `title` contents as ISO-8859-1.

We could improve the logic (e.g. check that there is not text content before `meta[charset]`) or insert the tag unconditionally but it will probably be simplest to just go back to converting the non-ASCII characters to entities, just using non-deprecated function variant.

Fixes: https://github.com/wallabag/wallabag/issues/8158
