### PR TITLE
Fix bad encoding for `tidy_repair_string`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,11 +3,9 @@ name: "CI"
 on:
   pull_request:
     branches:
-      - "master"
       - "1.x"
   push:
     branches:
-      - "master"
       - "1.x"
 
 env:
@@ -29,6 +27,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
     steps:
       - name: "Checkout"

--- a/src/Readability.php
+++ b/src/Readability.php
@@ -118,7 +118,7 @@ class Readability implements LoggerAwareInterface
         'enclose-text' => true,
         'merge-divs' => true,
         // 'merge-spans' => true,
-        'input-encoding' => '????',
+        'input-encoding' => 'utf8',
         'output-encoding' => 'utf8',
         'hide-comments' => true,
     ];

--- a/tests/ReadabilityTest.php
+++ b/tests/ReadabilityTest.php
@@ -17,6 +17,7 @@ class ReadabilityTest extends \PHPUnit\Framework\TestCase
     public function testConstructDefault()
     {
         $readability = $this->getReadability('');
+        $this->assertSame('utf8', $readability->tidy_config['input-encoding']);
 
         $this->assertNull($readability->url);
         $this->assertInstanceOf(\DOMDocument::class, $readability->dom);


### PR DESCRIPTION
Backport https://github.com/j0k3r/php-readability/pull/111