### PR TITLE
Fix "Undefined array key 0" error

### DIFF
--- a/src/Readability.php
+++ b/src/Readability.php
@@ -1483,8 +1483,15 @@ class Readability implements LoggerAwareInterface
         $childNodes = iterator_to_array($node->childNodes);
         $children = array_filter($childNodes, static fn ($childNode) => $childNode instanceof \DOMElement);
 
+        // array_first() has been added in PHP 8.5, failing back for older versions
+        if (!\function_exists('array_first')) {
+            $firstChild = $children ? $children[array_key_first($children)] : null;
+        } else {
+            $firstChild = array_first($children);
+        }
+
         // There should be exactly 1 element child with given tag
-        if (1 !== \count($children) || $children[0]->nodeName !== $tag) {
+        if (1 !== \count($children) || $firstChild->nodeName !== $tag) {
             return false;
         }
 

--- a/tests/ReadabilityTest.php
+++ b/tests/ReadabilityTest.php
@@ -464,6 +464,49 @@ class ReadabilityTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($res);
     }
 
+    public function dataForHasSingleTagInsideElement(): array
+    {
+        return [
+            'single matching tag, no other content' => [
+                '<div><p>Some text</p></div>', 'p', true,
+            ],
+            'single matching tag with comment' => [
+                '<div><!-- comment --><p>Some text</p></div>', 'p', true,
+            ],
+            'whitespace-only text around single matching tag' => [
+                '<div>   <p>Some text</p>   </div>', 'p', true,
+            ],
+            'two matching tags' => [
+                '<div><p>One</p><p>Two</p></div>', 'p', false,
+            ],
+            'non-whitespace text alongside the single tag' => [
+                '<div>Some text<p>One</p></div>', 'p', false,
+            ],
+            'single tag with a different name' => [
+                '<div><span>One</span></div>', 'p', false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataForHasSingleTagInsideElement
+     */
+    public function testHasSingleTagInsideElement(string $html, string $tag, bool $expected): void
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML('<html><body>' . $html . '</body></html>');
+        $node = $dom->getElementsByTagName('div')->item(0);
+
+        $readability = $this->getReadability('', '', 'libxml', false);
+
+        $method = new \ReflectionMethod($readability, 'hasSingleTagInsideElement');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $this->assertSame($expected, $method->invoke($readability, $node, $tag));
+    }
+
     public function testKeepFootnotes(): void
     {
         // from https://www.schreibdichte.de/blog/feed-aggregator-und-spaeter-lesen-dienst-im-team


### PR DESCRIPTION
If a matching element isn't the first child (_e.g. preceded by a whitespace text node_), the single remaining entry sits at a key other than 0, leading to the "Undefined array key 0" error.

Fixes #96

Depends on #115 #119 #120