### PR TITLE
Pin development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
         "masterminds/html5": "^2.7"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "friendsofphp/php-cs-fixer": "3.94.2",
         "monolog/monolog": "^1.24|^2.1",
         "symfony/phpunit-bridge": "^4.4|^5.3|^6.0|^7.0",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "rector/rector": "^2.0.0"
+        "phpstan/phpstan": "2.2.2",
+        "phpstan/phpstan-phpunit": "2.0.16",
+        "rector/rector": "2.4.6"
     },
     "suggest": {
         "ext-tidy": "Used to clean up given HTML and to avoid problems with bad HTML structure."


### PR DESCRIPTION
PHP-CS-Fixer, PHPStan and Rector regularly introduce changes which break CI in minor versions, forcing us to mix unrelated changes with CI fixes.

Let’s pin the minor version and update it on our own time e.g. with Dependabot.

This is also what PHPStan suggests for projects not using `composer.lock`:
https://phpstan.org/user-guide/backward-compatibility-promise#minimizing-impact-of-type-inference-changes
