### PR TITLE
composer: Stop using lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
         "masterminds/html5": "^2.7"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "friendsofphp/php-cs-fixer": "3.94.2",
         "monolog/monolog": "^1.24|^2.1",
         "symfony/phpunit-bridge": "^4.4|^5.3|^6.0|^7.0",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "rector/rector": "^2.0.0"
+        "phpstan/phpstan": "2.2.2",
+        "phpstan/phpstan-phpunit": "2.0.16",
+        "rector/rector": "2.4.6"
     },
     "suggest": {
         "ext-tidy": "Used to clean up given HTML and to avoid problems with bad HTML structure."

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
     "autoload-dev": {
         "psr-4": { "Tests\\Readability\\": "tests/" }
     },
+    "config": {
+        "lock": false
+    },
     "scripts": {
         "fix": "php-cs-fixer fix --verbose --diff",
         "phpstan": "phpstan analyze --memory-limit 512M",


### PR DESCRIPTION
Since we are a library that supports wide range of PHP versions,
we cannot lock into a single set of versions of run-time dependencies.

https://getcomposer.org/doc/02-libraries.md#lock-file

Composer 1.10.0 introduced `lock` option to prevent generation of `composer.lock` file:

https://github.com/composer/composer/releases/tag/1.10.0
https://getcomposer.org/doc/06-config.md#lock

This will basically make `composer install` work the same way as `composer update`.

Depends on #115
