### PR TITLE
.github: Set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will make GitHub check dependencies in `composer.json` once a week
and open PRs trying to bump each of them whenever a new version is released.
If the CI fails, as is likely the case with PHP-CS-Fixer, we will need
to fix is manually before the PR can be merged.

https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/dependabot-quickstart

Depends on #117
