### PR TITLE
php-cs-fixer: Prevent removing `strict_types` declaration

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -30,6 +30,8 @@ return (new PhpCsFixer\Config())
         'modernize_strpos' => false,
         // Pulled in by @Symfony, we cannot add property types until we bump PHP to ≥ 7.4
         'no_null_property_initialization' => false,
+        // @Symfony:risky started removing them but we will probably want to go the opposite direction.
+        'declare_strict_types' => false,
     ])
     ->setFinder($finder)
 ;


### PR DESCRIPTION
PHP-CS-Fixer 3.95.0 started removing the declarations as a part of
`@Symfony:risky` ruleset.

We currently only use it in `rector.php` but it works there so no point
in following Symfony code style on that.

We will probably want to enable `strict_types` globally eventually,
but let’s at least stop removing them for now so that we can bump
PHP-CS-Fixer.

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.95.0
https://cs.symfony.com/doc/rules/strict/declare_strict_types.html
