### PR TITLE
JSLikeHTMLElement: Add types to methods

### DIFF
--- a/src/JSLikeHTMLElement.php
+++ b/src/JSLikeHTMLElement.php
@@ -43,7 +43,7 @@ class JSLikeHTMLElement extends \DOMElement
      * $div->innerHTML = '<h2>Chapter 2</h2><p>The story begins...</p>';
      * ```
      */
-    public function __set($name, $value)
+    public function __set(string $name, string $value): void
     {
         if ('innerHTML' !== $name) {
             $trace = debug_backtrace();
@@ -108,7 +108,7 @@ class JSLikeHTMLElement extends \DOMElement
      * $string = $div->innerHTML;
      * ```
      */
-    public function __get($name)
+    public function __get(string $name): string
     {
         if ('innerHTML' === $name) {
             $inner = '';
@@ -124,20 +124,22 @@ class JSLikeHTMLElement extends \DOMElement
 
         $trace = debug_backtrace();
         trigger_error('Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'], \E_USER_NOTICE);
+
+        return '';
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return '[' . $this->tagName . ']';
     }
 
-    public function getInnerHtml()
+    public function getInnerHtml(): string
     {
         return $this->__get('innerHTML');
     }
 
-    public function setInnerHtml($value)
+    public function setInnerHtml(string $value): void
     {
-        return $this->__set('innerHTML', $value);
+        $this->__set('innerHTML', $value);
     }
 }


### PR DESCRIPTION
PHP-CS-Fixer 3.95.0 added `void_return` rule to `@Symfony:risky` ruleset.

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.95.0
https://cs.symfony.com/doc/rules/function_notation/void_return.html

`void` type declaration is available since PHP 7.1:
https://www.php.net/manual/en/language.types.void.php

Magic methods can have type annotations but they must be compatible with the default ones
(not enforced prior to PHP 8.0):
https://php.watch/versions/8.0/magic-method-signatures

Let’s just type all the methods.

This could technically be a BC break if someone is extending
the `JSLikeHTMLElement` class, overriding the methods that previously
did not have return type hint without adding it, and calling
`registerNodeClass` on the public `dom` property but I think it is
pretty unlikely – at least there seem to be no public instances on GitHub.
